### PR TITLE
refactor: centralize admin pagination hooks

### DIFF
--- a/src/hooks/useCompaniesPage.js
+++ b/src/hooks/useCompaniesPage.js
@@ -1,191 +1,135 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toastService from '../services/toastService';
 import { getCompanies, searchCompanies, deleteCompany } from '../services/companyService';
+import usePaginatedSearch from './usePaginatedSearch';
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10,
+  page: 1,
+  limit: 10,
+  total: 0
+};
+
+const parseCompaniesResponse = (response) => {
+  if (response?.success === false) {
+    throw new Error(response?.error?.message || 'Failed to load companies');
+  }
+
+  let rawData = response?.data?.data || response?.data?.companies || response?.data || [];
+  if (!Array.isArray(rawData)) {
+    rawData = Array.isArray(rawData?.data) ? rawData.data : [];
+  }
+
+  const paginationData = response?.data?.pagination || {};
+  const currentPage = paginationData.currentPage || paginationData.page || INITIAL_PAGINATION.currentPage;
+  const itemsPerPage = paginationData.itemsPerPage || paginationData.limit || INITIAL_PAGINATION.itemsPerPage;
+  const totalItems = paginationData.totalItems || paginationData.total || INITIAL_PAGINATION.totalItems;
+
+  return {
+    results: rawData,
+    pagination: {
+      currentPage,
+      page: currentPage,
+      totalPages: paginationData.totalPages || INITIAL_PAGINATION.totalPages,
+      totalItems,
+      total: totalItems,
+      itemsPerPage,
+      limit: itemsPerPage
+    }
+  };
+};
+
+const resolveCompanyError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Failed to load companies';
+};
 
 const useCompaniesPage = () => {
-  const [companies, setCompanies] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
-  });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
   const navigate = useNavigate();
 
-  const handleAuthError = useCallback(() => {
+  const handleAuthRedirect = useCallback(() => {
     localStorage.clear();
     navigate('/login');
     toastService.error('Session expired. Please login again.');
   }, [navigate]);
 
-  const fetchCompanies = useCallback(async (page = 1, limit = 10) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await getCompanies(page, limit);
-      
-      if (response.success) {
-        let companiesData = response.data?.data || response.data?.companies || response.data || [];
-        
-        // Ensure companiesData is always an array
-        if (!Array.isArray(companiesData)) {
-          console.warn('Companies data is not an array:', companiesData);
-          companiesData = [];
-        }
-        
-        const paginationData = response.data?.pagination || {
-          currentPage: 1,
-          totalPages: 1,
-          totalItems: 0,
-          itemsPerPage: 10
-        };
-        setCompanies(companiesData);
-        setPagination(paginationData);
-      } else {
-        throw new Error(response.error?.message || 'Failed to load companies');
+  const {
+    input: searchQuery,
+    setInput: setSearchQuery,
+    searchResults: companies,
+    setSearchResults: setCompanies,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
+    handleAuthError: authHandler,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (query, page, limit) => {
+      const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+      if (!trimmedQuery) {
+        return getCompanies(page, limit);
       }
-    } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
-        handleAuthError();
-      } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to load companies');
-      }
-      // Set fallback values on error
-      setCompanies([]);
-      setPagination({
-        currentPage: 1,
-        totalPages: 1,
-        totalItems: 0,
-        itemsPerPage: 10
-      });
-    } finally {
-      setLoading(false);
-    }
-  }, [handleAuthError]);
+      return searchCompanies(trimmedQuery, page, limit);
+    },
+    parseResponse: parseCompaniesResponse,
+    resolveErrorMessage: resolveCompanyError,
+    onAuthError: handleAuthRedirect
+  });
 
-  const searchCompaniesCallback = useCallback(async (query, page = 1, limit = 10) => {
-    if (!query.trim()) {
-      fetchCompanies(page, limit);
-      return;
+  const searchLoading = useMemo(() => {
+    if (typeof searchQuery !== 'string') {
+      return false;
     }
+    return loading && Boolean(searchQuery.trim());
+  }, [loading, searchQuery]);
 
-    try {
-      setSearchLoading(true);
-      setError(null);
-      const response = await searchCompanies(query, page, limit);
-      
-      if (response.success) {
-        let companiesData = response.data?.data || response.data?.companies || response.data || [];
-        
-        // Ensure companiesData is always an array
-        if (!Array.isArray(companiesData)) {
-          console.warn('Search companies data is not an array:', companiesData);
-          companiesData = [];
-        }
-        
-        setCompanies(companiesData);
-        setPagination(response.data?.pagination || {
-          currentPage: 1,
-          totalPages: 1,
-          totalItems: 0,
-          itemsPerPage: 10
-        });
-      } else {
-        throw new Error(response.error?.message || 'Failed to search companies');
-      }
-    } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
-        handleAuthError();
-      } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to search companies');
-      }
-      // Set fallback values on error
-      setCompanies([]);
-      setPagination({
-        currentPage: 1,
-        totalPages: 1,
-        totalItems: 0,
-        itemsPerPage: 10
-      });
-    } finally {
-      setSearchLoading(false);
-    }
-  }, [fetchCompanies, handleAuthError]);
+  const fetchCompanies = useCallback((page = 1, limit = resolveLimit()) => {
+    return performSearch('', page, limit);
+  }, [performSearch, resolveLimit]);
 
-  const handleDeleteCompany = async (id) => {
+  const handleSearchChange = useCallback((event) => {
+    const query = event?.target ? event.target.value : event;
+    setSearchQuery(query);
+    debouncedSearch(query, 1, resolveLimit());
+  }, [debouncedSearch, resolveLimit, setSearchQuery]);
+
+  const handleDeleteCompany = useCallback(async (id) => {
     try {
       await deleteCompany(id);
       toastService.success('Company deleted successfully');
-      
-      // Determine the page to fetch after deletion
-      const companiesArray = Array.isArray(companies) ? companies : [];
-      const newPage = (companiesArray.length === 1 && pagination.currentPage > 1)
-        ? pagination.currentPage - 1
-        : pagination.currentPage;
 
-      // Refresh the list based on whether a search is active
-      if (searchQuery.trim()) {
-        searchCompaniesCallback(searchQuery, newPage, pagination.itemsPerPage);
-      } else {
-        fetchCompanies(newPage, pagination.itemsPerPage);
-      }
+      const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+      const itemsPerPage = resolveLimit();
+      const currentPage = pagination.currentPage || pagination.page || 1;
+      const totalItems = pagination.totalItems || pagination.total || companies.length;
+      const newTotalItems = Math.max(totalItems - 1, 0);
+      const newTotalPages = Math.max(Math.ceil(newTotalItems / itemsPerPage), 1);
+      const nextPage = Math.min(currentPage, newTotalPages);
+
+      await performSearch(trimmedQuery, nextPage, itemsPerPage);
     } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
-        handleAuthError();
-      } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to delete company');
+      if (err?.response?.status === 401 || err?.response?.status === 403) {
+        authHandler();
+        return;
       }
+      const message = resolveCompanyError(err) || 'Failed to delete company';
+      setError(message);
+      toastService.error(message);
     }
-  };
-
-  const handleSearchChange = (e) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-
-    const timeout = setTimeout(() => {
-      searchCompaniesCallback(query, 1, pagination.itemsPerPage);
-    }, 500);
-
-    setDebounceTimeout(timeout);
-  };
-
-  const handlePageChange = (newPage) => {
-    if (searchQuery.trim()) {
-      searchCompaniesCallback(searchQuery, newPage, pagination.itemsPerPage);
-    } else {
-      fetchCompanies(newPage, pagination.itemsPerPage);
-    }
-  };
-
-  const handleLimitChange = (newLimit) => {
-    if (searchQuery.trim()) {
-      searchCompaniesCallback(searchQuery, 1, newLimit);
-    } else {
-      fetchCompanies(1, newLimit);
-    }
-  };
+  }, [authHandler, companies.length, pagination, performSearch, resolveLimit, searchQuery, setError]);
 
   useEffect(() => {
-    fetchCompanies(1, pagination.itemsPerPage);
-
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
+    fetchCompanies(1, INITIAL_PAGINATION.itemsPerPage);
   }, [fetchCompanies]);
 
   return {
@@ -198,11 +142,11 @@ const useCompaniesPage = () => {
     searchQuery,
     searchLoading,
     handleSearchChange,
-    handlePageChange,
-    handleLimitChange,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
     deleteCompany: handleDeleteCompany,
     fetchCompanies,
-    handleAuthError
+    handleAuthError: authHandler
   };
 };
 

--- a/src/hooks/useCustomersPage.js
+++ b/src/hooks/useCustomersPage.js
@@ -1,148 +1,135 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo } from 'react';
 import toastService from '../services/toastService';
 import customerService from '../services/customerService';
+import usePaginatedSearch from './usePaginatedSearch';
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  page: 1,
+  totalPages: 1,
+  totalItems: 0,
+  total: 0,
+  itemsPerPage: 10,
+  limit: 10
+};
+
+const parseCustomerResponse = (response) => {
+  if (!response?.success) {
+    throw new Error(response?.error?.message || 'Failed to load customers');
+  }
+
+  const data = response.data || {};
+  const paginationData = data.pagination || {};
+
+  const currentPage = paginationData.currentPage || paginationData.page || INITIAL_PAGINATION.currentPage;
+  const itemsPerPage = paginationData.itemsPerPage || paginationData.limit || INITIAL_PAGINATION.itemsPerPage;
+  const totalItems = paginationData.totalItems || paginationData.total || INITIAL_PAGINATION.totalItems;
+  const totalPages = paginationData.totalPages || INITIAL_PAGINATION.totalPages;
+
+  return {
+    results: data.data || [],
+    pagination: {
+      currentPage,
+      page: currentPage,
+      totalPages,
+      totalItems,
+      total: totalItems,
+      itemsPerPage,
+      limit: itemsPerPage
+    }
+  };
+};
+
+const resolveCustomerError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Failed to load customers';
+};
 
 const useCustomersPage = () => {
-  const [customers, setCustomers] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
+  const {
+    input: searchQuery,
+    setInput: setSearchQuery,
+    searchResults: customers,
+    setSearchResults: setCustomers,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange,
+    handleLimitChange,
+    clearSearch,
+    handleAuthError,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialInput: '',
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (query, page, limit) => {
+      const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+      if (!trimmedQuery) {
+        return customerService.getAllCustomers(page, limit);
+      }
+      return customerService.search(trimmedQuery, page, limit);
+    },
+    parseResponse: parseCustomerResponse,
+    resolveErrorMessage: resolveCustomerError,
+    requireInput: false
   });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
-  const navigate = useNavigate();
 
-  const handleAuthError = useCallback(() => {
-    localStorage.clear();
-    navigate('/login');
-    toastService.error('Session expired. Please login again.');
-  }, [navigate]);
+  useEffect(() => {
+    performSearch('', 1, INITIAL_PAGINATION.itemsPerPage);
+  }, [performSearch]);
 
-  const fetchCustomers = useCallback(async (page = 1, limit = 10) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const response = await customerService.getAllCustomers(page, limit);
-      
-      if (response.success) {
-        setCustomers(response.data.data);
-        setPagination(response.data.pagination);
-      } else {
-        throw new Error(response.error?.message || 'Failed to load customers');
-      }
-    } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
-        handleAuthError();
-      } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to load customers');
-      }
-    } finally {
-      setLoading(false);
+  const searchLoading = useMemo(() => {
+    if (typeof searchQuery !== 'string') {
+      return false;
     }
-  }, [handleAuthError]);
+    return loading && Boolean(searchQuery.trim());
+  }, [loading, searchQuery]);
 
-  const searchCustomers = useCallback(async (query, page = 1, limit = 10) => {
-    if (!query.trim()) {
-      fetchCustomers(page, limit);
-      return;
-    }
+  const handleSearchChange = useCallback((event) => {
+    const query = event?.target ? event.target.value : event;
+    setSearchQuery(query);
+    debouncedSearch(query, 1, resolveLimit());
+  }, [debouncedSearch, resolveLimit, setSearchQuery]);
 
-    try {
-      setSearchLoading(true);
-      setError(null);
-      const response = await customerService.search(query, page, limit);
-      
-      if (response.success) {
-        setCustomers(response.data.data);
-        setPagination(response.data.pagination);
-      } else {
-        throw new Error(response.error?.message || 'Failed to search customers');
-      }
-    } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
-        handleAuthError();
-      } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to search customers');
-      }
-    } finally {
-      setSearchLoading(false);
-    }
-  }, [fetchCustomers, handleAuthError]);
+  const fetchCustomers = useCallback((page = 1, limit = resolveLimit()) => {
+    return performSearch('', page, limit);
+  }, [performSearch, resolveLimit]);
 
-  const handleDeleteCustomer = async (id) => {
+  const searchCustomers = useCallback((query, page = 1, limit = resolveLimit()) => {
+    return performSearch(query, page, limit);
+  }, [performSearch, resolveLimit]);
+
+  const handleDeleteCustomer = useCallback(async (id) => {
     try {
       await customerService.deleteCustomer(id);
       toastService.success('Customer deleted successfully');
-      
-      // Determine the page to fetch after deletion
-      const newPage = (customers.length === 1 && pagination.currentPage > 1)
-        ? pagination.currentPage - 1
-        : pagination.currentPage;
 
-      // Refresh the list based on whether a search is active
-      if (searchQuery.trim()) {
-        searchCustomers(searchQuery, newPage, pagination.itemsPerPage);
-      } else {
-        fetchCustomers(newPage, pagination.itemsPerPage);
-      }
+      const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+      const itemsPerPage = resolveLimit();
+      const currentPage = pagination.currentPage || pagination.page || 1;
+      const totalItems = pagination.totalItems || pagination.total || customers.length;
+      const newTotalItems = Math.max(totalItems - 1, 0);
+      const newTotalPages = Math.max(Math.ceil(newTotalItems / itemsPerPage), 1);
+      const nextPage = Math.min(currentPage, newTotalPages);
+
+      await performSearch(trimmedQuery, nextPage, itemsPerPage);
     } catch (err) {
-      if (err.message.includes('401') || err.message.includes('403') || err.message.includes('Unauthorized')) {
+      if (err.message?.includes('401') || err.message?.includes('403') || err.message === 'Unauthorized') {
         handleAuthError();
       } else {
-        setError(err.message);
-        toastService.error(err.message || 'Failed to delete customer');
+        const message = err.message || 'Failed to delete customer';
+        setError(message);
+        toastService.error(message);
       }
     }
-  };
+  }, [customers.length, handleAuthError, pagination, performSearch, resolveLimit, searchQuery, setError]);
 
-  const handleSearchChange = (e) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-
-    const timeout = setTimeout(() => {
-      searchCustomers(query, 1, pagination.itemsPerPage);
-    }, 500);
-
-    setDebounceTimeout(timeout);
-  };
-
-  const handlePageChange = (newPage) => {
-    if (searchQuery.trim()) {
-      searchCustomers(searchQuery, newPage, pagination.itemsPerPage);
-    } else {
-      fetchCustomers(newPage, pagination.itemsPerPage);
-    }
-  };
-
-  const handleLimitChange = (newLimit) => {
-    if (searchQuery.trim()) {
-      searchCustomers(searchQuery, 1, newLimit);
-    } else {
-      fetchCustomers(1, newLimit);
-    }
-  };
-
-  useEffect(() => {
-    fetchCustomers(1, pagination.itemsPerPage);
-
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
-  }, [fetchCustomers]);
+  const clearSearchState = useCallback(() => {
+    clearSearch();
+  }, [clearSearch]);
 
   return {
     customers,
@@ -159,6 +146,7 @@ const useCustomersPage = () => {
     deleteCustomer: handleDeleteCustomer,
     fetchCustomers,
     searchCustomers,
+    clearSearch: clearSearchState,
     handleAuthError
   };
 };

--- a/src/hooks/useInvoiceSearch.js
+++ b/src/hooks/useInvoiceSearch.js
@@ -1,159 +1,130 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toastService from '../services/toastService';
 import invoiceService from '../services/invoiceService';
+import usePaginatedSearch from './usePaginatedSearch';
+
+const INITIAL_SEARCH_PARAMS = {
+  no_invoice: '',
+  deliver_to: '',
+  type: '',
+  statusPembayaranId: '',
+  purchaseOrderId: '',
+  tanggal_start: '',
+  tanggal_end: ''
+};
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10
+};
+
+const parseInvoiceResponse = (response) => {
+  if (!response?.success) {
+    throw new Error(response?.error?.message || 'Gagal melakukan pencarian');
+  }
+
+  return {
+    results: response.data?.data || [],
+    pagination: response.data?.pagination || INITIAL_PAGINATION
+  };
+};
+
+const resolveInvoiceError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Gagal melakukan pencarian';
+};
 
 const useInvoiceSearch = () => {
-  const [searchResults, setSearchResults] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
-  });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [searchParams, setSearchParams] = useState({
-    no_invoice: '',
-    deliver_to: '',
-    type: '',
-    statusPembayaranId: '',
-    purchaseOrderId: '',
-    tanggal_start: '',
-    tanggal_end: ''
-  });
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
   const navigate = useNavigate();
 
-  const handleAuthError = useCallback(() => {
-    localStorage.clear();
-    navigate('/login');
-    toastService.error('Session expired. Please login again.');
-  }, [navigate]);
+  const searchFn = useCallback(async (params, page, limit) => {
+    const filteredParams = Object.fromEntries(
+      Object.entries(params || {}).filter(([_, value]) => {
+        if (typeof value === 'string') {
+          return value.trim() !== '';
+        }
+        return value !== null && value !== undefined;
+      })
+    );
 
-  const performSearch = useCallback(async (params = searchParams, page = 1, limit = 10) => {
-    try {
-      setLoading(true);
-      setError(null);
-      
-      // Filter out empty values
-      const filteredParams = Object.fromEntries(
-        Object.entries(params).filter(([_, value]) => value && value.toString().trim() !== '')
-      );
-      
-      const result = await invoiceService.searchInvoices(filteredParams, page, limit);
-      
-      if (result.success) {
-        setSearchResults(result.data.data);
-        setPagination(result.data.pagination);
-      } else {
-        throw new Error(result.error?.message || 'Gagal melakukan pencarian');
-      }
-    } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
-      }
-      
-      const errorMessage = err.response?.data?.error?.message || err.message || 'Gagal melakukan pencarian';
-      setError(errorMessage);
-      toastService.error(errorMessage);
-    } finally {
-      setLoading(false);
+    return invoiceService.searchInvoices(filteredParams, page, limit);
+  }, []);
+
+  const {
+    input: searchParams,
+    setInput: setSearchParams,
+    searchResults,
+    setSearchResults,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange,
+    handleLimitChange,
+    clearSearch,
+    handleAuthError,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialInput: INITIAL_SEARCH_PARAMS,
+    initialPagination: INITIAL_PAGINATION,
+    searchFn,
+    parseResponse: parseInvoiceResponse,
+    resolveErrorMessage: resolveInvoiceError,
+    requireInput: false,
+    onAuthError: () => {
+      localStorage.clear();
+      navigate('/login');
+      toastService.error('Session expired. Please login again.');
     }
-  }, [searchParams, handleAuthError]);
+  });
 
   const handleSearchParamChange = useCallback((field, value) => {
     setSearchParams(prev => ({
       ...prev,
       [field]: value
     }));
-  }, []);
+  }, [setSearchParams]);
 
   const handleSearch = useCallback((params = searchParams, page = 1) => {
-    // Clear existing timeout
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-    
-    // Set new timeout for debounced search
-    const timeout = setTimeout(() => {
-      performSearch(params, page, pagination.itemsPerPage);
-    }, 500);
-    
-    setDebounceTimeout(timeout);
-  }, [searchParams, pagination.itemsPerPage, debounceTimeout, performSearch]);
+    debouncedSearch(params, page, resolveLimit(pagination));
+  }, [debouncedSearch, pagination, resolveLimit, searchParams]);
 
   const handleQuickSearch = useCallback((query, field = 'no_invoice') => {
     const newParams = {
       ...searchParams,
       [field]: query
     };
-    
+
     setSearchParams(newParams);
-    handleSearch(newParams, 1);
-  }, [searchParams, handleSearch]);
+    debouncedSearch(newParams, 1, resolveLimit(pagination));
+  }, [debouncedSearch, pagination, resolveLimit, searchParams, setSearchParams]);
 
   const handleAdvancedSearch = useCallback((params) => {
     setSearchParams(params);
-    handleSearch(params, 1);
-  }, [handleSearch]);
+    performSearch(params, 1, resolveLimit(pagination));
+  }, [performSearch, pagination, resolveLimit, setSearchParams]);
 
-  const clearSearch = useCallback(() => {
-    const emptyParams = {
-      no_invoice: '',
-      deliver_to: '',
-      type: '',
-      statusPembayaranId: '',
-      purchaseOrderId: '',
-      tanggal_start: '',
-      tanggal_end: ''
-    };
-    
-    setSearchParams(emptyParams);
-    setSearchResults([]);
-    setPagination({
-      currentPage: 1,
-      totalPages: 1,
-      totalItems: 0,
-      itemsPerPage: 10
-    });
-    setError(null);
-  }, []);
-
-  const handlePageChange = useCallback((newPage) => {
-    handleSearch(searchParams, newPage);
-  }, [searchParams, handleSearch]);
-
-  const handleLimitChange = useCallback((newLimit) => {
-    setPagination(prev => ({
-      ...prev,
-      itemsPerPage: newLimit
-    }));
-    handleSearch(searchParams, 1);
-  }, [searchParams, handleSearch]);
+  const clearSearchState = useCallback(() => {
+    clearSearch();
+  }, [clearSearch]);
 
   const getSearchSummary = useCallback(() => {
     const activeFilters = Object.entries(searchParams)
       .filter(([_, value]) => value && value.toString().trim() !== '')
       .map(([key, value]) => `${key}: ${value}`)
       .join(', ');
-    
+
     return activeFilters ? `Filter aktif: ${activeFilters}` : 'Tidak ada filter aktif';
   }, [searchParams]);
 
   const hasActiveFilters = useCallback(() => {
     return Object.values(searchParams).some(value => value && value.toString().trim() !== '');
   }, [searchParams]);
-
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
-  }, [debounceTimeout]);
 
   return {
     searchResults,
@@ -162,6 +133,7 @@ const useInvoiceSearch = () => {
     setPagination,
     loading,
     error,
+    setError,
     searchParams,
     setSearchParams,
     performSearch,
@@ -169,7 +141,7 @@ const useInvoiceSearch = () => {
     handleSearch,
     handleQuickSearch,
     handleAdvancedSearch,
-    clearSearch,
+    clearSearch: clearSearchState,
     handlePageChange,
     handleLimitChange,
     getSearchSummary,

--- a/src/hooks/useInvoicesPage.js
+++ b/src/hooks/useInvoicesPage.js
@@ -1,147 +1,202 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toastService from '../services/toastService';
 import invoiceService from '../services/invoiceService';
+import usePaginatedSearch from './usePaginatedSearch';
 import { useDeleteConfirmation } from './useDeleteConfirmation';
 
-const API_URL = 'http://localhost:5050/api/v1';
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10,
+  page: 1,
+  limit: 10,
+  total: 0
+};
+
+const parseInvoicesResponse = (response) => {
+  if (response?.success === false) {
+    throw new Error(response?.error?.message || 'Failed to fetch invoices');
+  }
+
+  const rawData = response?.data?.data || response?.data || [];
+  const paginationData = response?.data?.pagination || {};
+  const currentPage = paginationData.currentPage || paginationData.page || INITIAL_PAGINATION.currentPage;
+  const itemsPerPage = paginationData.itemsPerPage || paginationData.limit || INITIAL_PAGINATION.itemsPerPage;
+  const totalItems = paginationData.totalItems || paginationData.total || INITIAL_PAGINATION.totalItems;
+
+  return {
+    results: Array.isArray(rawData) ? rawData : Array.isArray(rawData?.data) ? rawData.data : [],
+    pagination: {
+      currentPage,
+      page: currentPage,
+      totalPages: paginationData.totalPages || INITIAL_PAGINATION.totalPages,
+      totalItems,
+      total: totalItems,
+      itemsPerPage,
+      limit: itemsPerPage
+    }
+  };
+};
+
+const resolveInvoiceError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Failed to load invoices';
+};
 
 const useInvoices = () => {
-  const [invoices, setInvoices] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
-  });
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchField, setSearchField] = useState('no_invoice');
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
   const navigate = useNavigate();
+  const [searchField, setSearchField] = useState('no_invoice');
+  const searchFieldRef = useRef('no_invoice');
 
-  const handleAuthError = useCallback(() => {
+  const handleAuthRedirect = useCallback(() => {
     localStorage.clear();
     navigate('/login');
     toastService.error('Session expired. Please login again.');
   }, [navigate]);
 
-  const fetchInvoices = useCallback(async (page = 1, limit = 10) => {
-    try {
-      setLoading(true);
-      const result = await invoiceService.getAllInvoices(page, limit);
-      
-      if (result.success) {
-        setInvoices(result.data.data);
-        setPagination(result.data.pagination);
-      } else {
-        throw new Error(result.error?.message || 'Failed to fetch invoices');
+  const {
+    input: searchQuery,
+    setInput: setSearchQuery,
+    searchResults: invoices,
+    setSearchResults: setInvoices,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
+    handleAuthError: authHandler,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (query, page, limit) => {
+      const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+      const field = searchFieldRef.current || 'no_invoice';
+      if (!trimmedQuery) {
+        return invoiceService.getAllInvoices(page, limit);
       }
-    } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
-      }
-      setError(err.message);
-      toastService.error('Failed to load invoices');
-    } finally {
-      setLoading(false);
-    }
-  }, [handleAuthError]);
+      const searchParams = { [field]: trimmedQuery };
+      return invoiceService.searchInvoices(searchParams, page, limit);
+    },
+    parseResponse: parseInvoicesResponse,
+    resolveErrorMessage: resolveInvoiceError,
+    onAuthError: handleAuthRedirect
+  });
 
-  const searchInvoices = useCallback(async (query, field, page = 1, limit = 10) => {
-    if (!query.trim()) {
-      fetchInvoices(page, limit);
-      return;
+  const searchLoading = useMemo(() => {
+    if (typeof searchQuery !== 'string') {
+      return false;
     }
+    return loading && Boolean(searchQuery.trim());
+  }, [loading, searchQuery]);
 
-    try {
-      setSearchLoading(true);
-      const searchParams = {};
-      searchParams[field] = query;
-      const result = await invoiceService.searchInvoices(searchParams, page, limit);
-      
-      if (result.success) {
-        setInvoices(result.data.data);
-        setPagination(result.data.pagination);
-      } else {
-        throw new Error(result.error?.message || 'Failed to search invoices');
-      }
-    } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
-      }
-      toastService.error('Failed to search invoices');
-    } finally {
-      setSearchLoading(false);
+  const fetchInvoices = useCallback((page = 1, limit = resolveLimit()) => {
+    return performSearch('', page, limit);
+  }, [performSearch, resolveLimit]);
+
+  const searchInvoices = useCallback((query, field = searchFieldRef.current, page = 1, limit = resolveLimit()) => {
+    if (field && field !== searchFieldRef.current) {
+      searchFieldRef.current = field;
+      setSearchField(field);
     }
-  }, [fetchInvoices, handleAuthError]);
+    setSearchQuery(query);
+    return performSearch(query, page, limit);
+  }, [performSearch, resolveLimit, setSearchQuery]);
 
-  const createInvoice = async (invoiceData) => {
+  const handleSearchChange = useCallback((event) => {
+    const query = event?.target ? event.target.value : event;
+    setSearchQuery(query);
+    debouncedSearch(query, 1, resolveLimit());
+  }, [debouncedSearch, resolveLimit, setSearchQuery]);
+
+  const handleSearchFieldChange = useCallback((field) => {
+    searchFieldRef.current = field;
+    setSearchField(field);
+    if (typeof searchQuery === 'string' && searchQuery.trim()) {
+      performSearch(searchQuery, 1, resolveLimit());
+    } else {
+      performSearch('', 1, resolveLimit());
+    }
+  }, [performSearch, resolveLimit, searchQuery]);
+
+  const refreshAfterMutation = useCallback(async () => {
+    const itemsPerPage = resolveLimit();
+    const currentPage = pagination.currentPage || pagination.page || 1;
+    const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+    await performSearch(trimmedQuery, currentPage, itemsPerPage);
+  }, [pagination, performSearch, resolveLimit, searchQuery]);
+
+  const createInvoice = useCallback(async (invoiceData) => {
     try {
       const result = await invoiceService.createInvoice(invoiceData);
-      
-      if (result.success) {
-        toastService.success('Invoice created successfully');
-        // Refresh the invoices list
-        fetchInvoices(pagination.currentPage, pagination.itemsPerPage);
-        return result.data;
-      } else {
-        throw new Error(result.error?.message || 'Failed to create invoice');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to create invoice');
       }
+      toastService.success('Invoice created successfully');
+      await refreshAfterMutation();
+      return result?.data;
     } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
+      if (err?.response?.status === 401 || err?.response?.status === 403) {
+        authHandler();
+        return undefined;
       }
-      toastService.error('Failed to create invoice');
+      const message = err?.response?.data?.error?.message || err?.message || 'Failed to create invoice';
+      toastService.error(message);
       throw err;
     }
-  };
+  }, [authHandler, refreshAfterMutation]);
 
-  const updateInvoice = async (id, updateData) => {
+  const updateInvoice = useCallback(async (id, updateData) => {
     try {
       const result = await invoiceService.updateInvoice(id, updateData);
-      
-      if (result.success) {
-        toastService.success('Invoice updated successfully');
-        // Refresh the invoices list
-        fetchInvoices(pagination.currentPage, pagination.itemsPerPage);
-        return result.data;
-      } else {
-        throw new Error(result.error?.message || 'Failed to update invoice');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to update invoice');
       }
+      toastService.success('Invoice updated successfully');
+      await refreshAfterMutation();
+      return result?.data;
     } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
+      if (err?.response?.status === 401 || err?.response?.status === 403) {
+        authHandler();
+        return undefined;
       }
-      toastService.error('Failed to update invoice');
+      const message = err?.response?.data?.error?.message || err?.message || 'Failed to update invoice';
+      toastService.error(message);
       throw err;
     }
-  };
+  }, [authHandler, refreshAfterMutation]);
 
-  const deleteInvoiceFunction = async (id) => {
+  const deleteInvoiceFunction = useCallback(async (id) => {
     try {
       const result = await invoiceService.deleteInvoice(id);
-      
-      if (result.success || result === '') {
-        setInvoices(invoices.filter((invoice) => invoice.id !== id));
-        toastService.success('Invoice deleted successfully');
-      } else {
-        throw new Error(result.error?.message || 'Failed to delete invoice');
+      if (!(result?.success || result === '')) {
+        throw new Error(result?.error?.message || 'Failed to delete invoice');
       }
+      toastService.success('Invoice deleted successfully');
+
+      const itemsPerPage = resolveLimit();
+      const currentPage = pagination.currentPage || pagination.page || 1;
+      const totalItems = pagination.totalItems || pagination.total || invoices.length;
+      const newTotalItems = Math.max(totalItems - 1, 0);
+      const newTotalPages = Math.max(Math.ceil(newTotalItems / itemsPerPage), 1);
+      const nextPage = Math.min(currentPage, newTotalPages);
+      const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+
+      await performSearch(trimmedQuery, nextPage, itemsPerPage);
     } catch (err) {
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
+      if (err?.response?.status === 401 || err?.response?.status === 403) {
+        authHandler();
         return;
       }
-      toastService.error('Failed to delete invoice');
+      const message = err?.response?.data?.error?.message || err?.message || 'Failed to delete invoice';
+      setError(message);
+      toastService.error(message);
     }
-  };
+  }, [authHandler, invoices.length, pagination, performSearch, resolveLimit, searchQuery, setError]);
 
   const deleteInvoiceConfirmation = useDeleteConfirmation(
     deleteInvoiceFunction,
@@ -149,64 +204,8 @@ const useInvoices = () => {
     'Delete Invoice'
   );
 
-  const deleteInvoice = deleteInvoiceConfirmation.showDeleteConfirmation;
-
-  const handleSearchChange = (e) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-
-    const timeout = setTimeout(() => {
-      searchInvoices(query, searchField, 1, pagination.itemsPerPage); // Reset to first page when searching
-    }, 500);
-
-    setDebounceTimeout(timeout);
-  };
-
-  const handleSearchFieldChange = (field) => {
-    setSearchField(field);
-    setSearchQuery('');
-
-    // If there's a current search, perform it with the new field
-    if (searchQuery.trim()) {
-      searchInvoices(searchQuery, field, 1, pagination.itemsPerPage);
-    } else {
-      fetchInvoices(1, pagination.itemsPerPage);
-    }
-  };
-
-  const handlePageChange = (newPage) => {
-    if (searchQuery.trim()) {
-      searchInvoices(searchQuery, searchField, newPage, pagination.itemsPerPage);
-    } else {
-      fetchInvoices(newPage, pagination.itemsPerPage);
-    }
-  };
-
-  const handleLimitChange = (newLimit) => {
-    const newPagination = {
-      ...pagination,
-      itemsPerPage: newLimit
-    };
-    setPagination(newPagination);
-
-    if (searchQuery.trim()) {
-      searchInvoices(searchQuery, searchField, 1, newLimit); // Reset to first page when changing limit
-    } else {
-      fetchInvoices(1, newLimit); // Reset to first page when changing limit
-    }
-  };
   useEffect(() => {
-    fetchInvoices(1, pagination.itemsPerPage); // Start on first page
-
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
+    fetchInvoices(1, INITIAL_PAGINATION.itemsPerPage);
   }, [fetchInvoices]);
 
   return {
@@ -221,14 +220,14 @@ const useInvoices = () => {
     searchLoading,
     handleSearchChange,
     handleSearchFieldChange,
-    handlePageChange,
-    handleLimitChange,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
     createInvoice,
     updateInvoice,
-    deleteInvoice,
+    deleteInvoice: deleteInvoiceConfirmation.showDeleteConfirmation,
     deleteInvoiceConfirmation,
     fetchInvoices,
-    handleAuthError
+    handleAuthError: authHandler
   };
 };
 

--- a/src/hooks/usePackingsPage.js
+++ b/src/hooks/usePackingsPage.js
@@ -1,266 +1,245 @@
-import { useState, useEffect, useCallback } from 'react';
-import { 
-  getPackings, 
-  searchPackingsByStatus, 
-  getPackingById, 
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import {
+  getPackings,
+  getPackingById,
   searchPackings,
   searchPackingsAdvanced,
   deletePacking,
   processPackings
 } from '../services/packingService';
 import toastService from '../services/toastService';
+import usePaginatedSearch from './usePaginatedSearch';
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10,
+  page: 1,
+  limit: 10,
+  total: 0
+};
+
+const parsePackingsResponse = (response) => {
+  if (response?.success === false) {
+    throw new Error(response?.error?.message || 'Gagal memuat data packing');
+  }
+
+  const rawData = response?.data?.data || response?.data || [];
+  const paginationData = response?.data?.pagination || response?.pagination || {};
+  const currentPage = paginationData.currentPage || paginationData.page || INITIAL_PAGINATION.currentPage;
+  const itemsPerPage = paginationData.itemsPerPage || paginationData.limit || INITIAL_PAGINATION.itemsPerPage;
+  const totalItems = paginationData.totalItems || paginationData.total || INITIAL_PAGINATION.totalItems;
+
+  const results = Array.isArray(rawData)
+    ? rawData
+    : Array.isArray(rawData?.data)
+      ? rawData.data
+      : [];
+
+  return {
+    results,
+    pagination: {
+      currentPage,
+      page: currentPage,
+      totalPages: paginationData.totalPages || INITIAL_PAGINATION.totalPages,
+      totalItems,
+      total: totalItems,
+      itemsPerPage,
+      limit: itemsPerPage
+    }
+  };
+};
+
+const resolvePackingsError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Terjadi kesalahan saat memuat packing';
+};
 
 const usePackingsPage = () => {
-  const [packings, setPackingsData] = useState([]);
-  const [pagination, setPagination] = useState({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchField, setSearchField] = useState('packing_number');
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
+  const [searchFilters, setSearchFilters] = useState({});
   const [viewingPacking, setViewingPacking] = useState(null);
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteConfirmId, setDeleteConfirmId] = useState(null);
-  const [searchFilters, setSearchFilters] = useState({});
   const [selectedPackings, setSelectedPackings] = useState([]);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  // Helper function to safely set packings data
-  const setPackingsDataData = (data) => {
-    if (Array.isArray(data)) {
-      setPackingsData(data);
-    } else {
-      console.warn('setPackingsDataData received non-array data:', data);
-      setPackingsData([]);
-    }
-  };
+  const searchFieldRef = useRef('packing_number');
 
-  const fetchPackings = useCallback(async (page = 1) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const response = await getPackings(page);
-      console.log('API Response:', response); // Debug log
-      
-      if (response && response.success && response.data) {
-        // Handle API response structure: { success: true, data: { data: [...], pagination: {...} } }
-        const packingsData = Array.isArray(response.data.data) ? response.data.data : [];
-        const paginationData = response.data.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 };
-        
-        setPackingsData(packingsData);
-        setPagination(paginationData);
-      } else if (response && Array.isArray(response.data)) {
-        // Handle direct array response
-        setPackingsData(response.data);
-        setPagination(response.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-      } else {
-        setPackingsData([]);
-        setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
+  const {
+    input: currentSearchValue,
+    setInput: setSearchInput,
+    searchResults: packings,
+    setSearchResults: setPackings,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (value, page) => {
+      if (value && typeof value === 'object' && value.type === 'filters') {
+        return searchPackingsAdvanced(value.filters || {}, page);
       }
-    } catch (err) {
-      const errorMessage = err.message || 'An unexpected error occurred.';
-      setError(errorMessage);
-      toastService.error(errorMessage);
-      setPackingsData([]);
-      setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
 
-  const searchPackingsData = useCallback(async (query, field, page = 1) => {
-    if (!query.trim()) {
-      fetchPackings(page);
-      return;
-    }
+      const trimmedQuery = typeof value === 'string' ? value.trim() : '';
+      const field = searchFieldRef.current || 'packing_number';
 
-    try {
-      setSearchLoading(true);
-      const response = await searchPackings(query, field, page);
-      console.log('Search API Response:', response); // Debug log
-      
-      if (response && response.success && response.data) {
-        // Handle API response structure: { success: true, data: { data: [...], pagination: {...} } }
-        const packingsData = Array.isArray(response.data.data) ? response.data.data : [];
-        const paginationData = response.data.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 };
-        
-        setPackingsData(packingsData);
-        setPagination(paginationData);
-      } else if (response && Array.isArray(response.data)) {
-        // Handle direct array response
-        setPackingsData(response.data);
-        setPagination(response.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-      } else {
-        setPackingsData([]);
-        setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
+      if (!trimmedQuery) {
+        return getPackings(page);
       }
-    } catch (err) {
-      const errorMessage = err.message || 'Failed to search packings';
-      toastService.error(errorMessage);
-      setPackingsData([]);
-      setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-    } finally {
-      setSearchLoading(false);
-    }
-  }, [fetchPackings]);
 
-  const searchPackingsWithFilters = useCallback(async (filters, page = 1) => {
-    try {
-      setSearchLoading(true);
-      const response = await searchPackingsAdvanced(filters, page);
-      console.log('Advanced Search API Response:', response); // Debug log
-      
-      if (response && response.success && response.data) {
-        // Handle API response structure: { success: true, data: { data: [...], pagination: {...} } }
-        const packingsData = Array.isArray(response.data.data) ? response.data.data : [];
-        const paginationData = response.data.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 };
-        
-        setPackingsData(packingsData);
-        setPagination(paginationData);
-      } else if (response && Array.isArray(response.data)) {
-        // Handle direct array response
-        setPackingsData(response.data);
-        setPagination(response.pagination || { currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-      } else {
-        setPackingsData([]);
-        setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-      }
-    } catch (err) {
-      const errorMessage = err.message || 'Failed to search packings with filters';
-      toastService.error(errorMessage);
-      setPackingsData([]);
-      setPagination({ currentPage: 1, totalPages: 1, totalItems: 0, itemsPerPage: 10 });
-    } finally {
-      setSearchLoading(false);
-    }
-  }, []);
+      return searchPackings(trimmedQuery, field, page);
+    },
+    parseResponse: parsePackingsResponse,
+    resolveErrorMessage: resolvePackingsError
+  });
+
+  const searchLoading = useMemo(() => {
+    const hasFilters = Object.keys(searchFilters || {}).length > 0;
+    return loading && (Boolean(searchQuery.trim()) || hasFilters || typeof currentSearchValue === 'object');
+  }, [currentSearchValue, loading, searchFilters, searchQuery]);
+
+  const fetchPackings = useCallback((page = 1) => {
+    setSearchFilters({});
+    setSearchInput('');
+    return performSearch('', page, resolveLimit());
+  }, [performSearch, resolveLimit, setSearchInput]);
+
+  const searchPackingsData = useCallback((query, field = searchFieldRef.current, page = 1) => {
+    searchFieldRef.current = field;
+    setSearchField(field);
+    setSearchFilters({});
+    setSearchQuery(query);
+    setSearchInput(query);
+    return performSearch(query, page, resolveLimit());
+  }, [performSearch, resolveLimit, setSearchInput]);
+
+  const searchPackingsWithFilters = useCallback((filters, page = 1) => {
+    setSearchFilters(filters);
+    setSearchQuery('');
+    const payload = { type: 'filters', filters };
+    setSearchInput(payload);
+    return performSearch(payload, page, resolveLimit());
+  }, [performSearch, resolveLimit, setSearchInput]);
+
+const clearFilters = useCallback(() => {
+    setSearchFilters({});
+    setSearchQuery('');
+    setSelectedPackings([]);
+    setSearchInput('');
+    performSearch('', 1, resolveLimit());
+  }, [performSearch, resolveLimit, setSearchInput]);
 
   useEffect(() => {
     fetchPackings(1);
-
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
   }, [fetchPackings]);
 
-  const handleSearchChange = (e) => {
-    const query = e.target.value;
+  const handleSearchChange = useCallback((event) => {
+    const query = event?.target ? event.target.value : event;
     setSearchQuery(query);
+    setSearchFilters({});
+    setSearchInput(query);
+    debouncedSearch(query, 1, resolveLimit());
+  }, [debouncedSearch, resolveLimit, setSearchInput]);
 
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-
-    const timeout = setTimeout(() => {
-      searchPackingsData(query, searchField, 1); // Reset to first page when searching
-    }, 500);
-
-    setDebounceTimeout(timeout);
-  };
-
-  const handleSearchFieldChange = (field) => {
+  const handleSearchFieldChange = useCallback((field) => {
+    searchFieldRef.current = field;
     setSearchField(field);
     if (searchQuery.trim()) {
-      searchPackingsData(searchQuery, field, 1);
+      performSearch(searchQuery, 1, resolveLimit());
     }
-  };
+  }, [performSearch, resolveLimit, searchQuery]);
 
-  const handlePageChange = (page) => {
-    if (searchQuery.trim()) {
-      searchPackingsData(searchQuery, searchField, page);
-    } else {
-      fetchPackings(page);
-    }
-  };
+  const handlePageChange = useCallback((page) => {
+    handlePageChangeInternal(page);
+  }, [handlePageChangeInternal]);
 
-  const openViewModal = async (id) => {
-    try {
-      const response = await getPackingById(id);
-      
-      // Handle API response structure: { success: true, data: {...} }
-      const packing = response?.success ? response.data : response;
-      
-      setViewingPacking(packing);
-      setIsViewModalOpen(true);
-    } catch (err) {
-      const errorMessage = err.message || 'Error fetching packing details.';
-      toastService.error(errorMessage);
-    }
-  };
-
-  const closeViewModal = () => {
-    setIsViewModalOpen(false);
-    setViewingPacking(null);
-  };
-
-  const refreshPackings = () => {
-    if (searchQuery.trim()) {
-      searchPackingsData(searchQuery, searchField, pagination.currentPage);
-    } else {
-      fetchPackings(pagination.currentPage);
-    }
-  };
-
-  const handleDeletePacking = async (id) => {
+  const handleDeletePacking = useCallback(async (id) => {
     setIsDeleting(true);
     try {
       await deletePacking(id);
       toastService.success('Packing berhasil dihapus');
-      refreshPackings();
+
+      const itemsPerPage = resolveLimit();
+      const currentPage = pagination.currentPage || pagination.page || 1;
+      const totalItems = pagination.totalItems || pagination.total || packings.length;
+      const newTotalItems = Math.max(totalItems - 1, 0);
+      const newTotalPages = Math.max(Math.ceil(newTotalItems / itemsPerPage), 1);
+      const nextPage = Math.min(currentPage, newTotalPages);
+
+      await performSearch(currentSearchValue, nextPage, itemsPerPage);
     } catch (err) {
-      const errorMessage = err.message || 'Gagal menghapus packing';
-      toastService.error(errorMessage);
+      const message = err?.response?.data?.error?.message || err?.message || 'Gagal menghapus packing';
+      setError(message);
+      toastService.error(message);
     } finally {
       setIsDeleting(false);
       setDeleteConfirmId(null);
     }
-  };
+  }, [currentSearchValue, packings.length, pagination, performSearch, resolveLimit, setError]);
 
-  const confirmDelete = (id) => {
+  const openViewModal = useCallback(async (id) => {
+    try {
+      const response = await getPackingById(id);
+      const packing = response?.success ? response.data : response;
+      setViewingPacking(packing);
+      setIsViewModalOpen(true);
+    } catch (err) {
+      const message = err?.response?.data?.error?.message || err?.message || 'Error fetching packing details.';
+      toastService.error(message);
+    }
+  }, []);
+
+  const closeViewModal = useCallback(() => {
+    setIsViewModalOpen(false);
+    setViewingPacking(null);
+  }, []);
+
+  const refreshPackings = useCallback(() => {
+    const currentPage = pagination.currentPage || pagination.page || 1;
+    performSearch(currentSearchValue, currentPage, resolveLimit());
+  }, [currentSearchValue, pagination, performSearch, resolveLimit]);
+
+  const confirmDelete = useCallback((id) => {
     setDeleteConfirmId(id);
-  };
+  }, []);
 
-  const cancelDelete = () => {
+  const cancelDelete = useCallback(() => {
     setDeleteConfirmId(null);
-  };
+  }, []);
 
-  const handleFilterChange = (filters) => {
+  const handleFilterChange = useCallback((filters) => {
     setSearchFilters(filters);
     searchPackingsWithFilters(filters, 1);
-  };
+  }, [searchPackingsWithFilters]);
 
-  const clearFilters = () => {
-    setSearchFilters({});
-    setSearchQuery('');
-    setSelectedPackings([]);
-    fetchPackings(1);
-  };
-
-  // Handle packing selection
-  const handleSelectPacking = (packingId) => {
+  const handleSelectPacking = useCallback((packingId) => {
     setSelectedPackings(prev => {
       if (prev.includes(packingId)) {
         return prev.filter(id => id !== packingId);
-      } else {
-        return [...prev, packingId];
       }
+      return [...prev, packingId];
     });
-  };
+  }, []);
 
-  const handleSelectAllPackings = () => {
+  const handleSelectAllPackings = useCallback(() => {
     if (selectedPackings.length === packings.length) {
       setSelectedPackings([]);
     } else {
       setSelectedPackings(packings.map(packing => packing.id));
     }
-  };
+  }, [packings, selectedPackings.length]);
 
-  // Handle process packing
-  const handleProcessPackings = async () => {
+  const handleProcessPackings = useCallback(async () => {
     if (selectedPackings.length === 0) {
       toastService.error('Pilih minimal satu packing untuk diproses');
       return;
@@ -269,44 +248,48 @@ const usePackingsPage = () => {
     setIsProcessing(true);
     try {
       const response = await processPackings(selectedPackings);
-      
-      if (response && response.success) {
+      if (response?.success) {
         const { processedCount, processedPackingItemsCount } = response.data;
-        toastService.success(
-          `Berhasil memproses ${processedCount} packing dengan ${processedPackingItemsCount} item`
-        );
+        toastService.success(`Berhasil memproses ${processedCount} packing dengan ${processedPackingItemsCount} item`);
         setSelectedPackings([]);
         refreshPackings();
       } else {
         toastService.error(response?.error?.message || 'Gagal memproses packing');
       }
     } catch (err) {
-      const errorMessage = err.message || 'Gagal memproses packing';
-      toastService.error(errorMessage);
+      const message = err?.response?.data?.error?.message || err?.message || 'Gagal memproses packing';
+      toastService.error(message);
     } finally {
       setIsProcessing(false);
     }
-  };
+  }, [processPackings, refreshPackings, selectedPackings]);
 
   return {
     packings,
     pagination,
+    setPagination,
     loading,
     error,
+    setError,
     searchQuery,
     searchField,
+    searchFilters,
     searchLoading,
     viewingPacking,
     isViewModalOpen,
     isDeleting,
     deleteConfirmId,
-    searchFilters,
     selectedPackings,
     isProcessing,
     hasSelectedPackings: selectedPackings.length > 0,
     handleSearchChange,
     handleSearchFieldChange,
     handlePageChange,
+    handleLimitChange: handleLimitChangeInternal,
+    fetchPackings,
+    searchPackingsData,
+    searchPackingsWithFilters,
+    clearFilters,
     openViewModal,
     closeViewModal,
     refreshPackings,
@@ -314,8 +297,6 @@ const usePackingsPage = () => {
     confirmDelete,
     cancelDelete,
     handleFilterChange,
-    clearFilters,
-    searchPackingsWithFilters,
     handleSelectPacking,
     handleSelectAllPackings,
     handleProcessPackings
@@ -323,4 +304,3 @@ const usePackingsPage = () => {
 };
 
 export default usePackingsPage;
-

--- a/src/hooks/usePaginatedSearch.js
+++ b/src/hooks/usePaginatedSearch.js
@@ -1,0 +1,223 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import toastService from '../services/toastService';
+
+const DEFAULT_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10
+};
+
+const isValueEmpty = (value) => {
+  if (value == null) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+
+  if (typeof value === 'number') {
+    return Number.isNaN(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value).every(isValueEmpty);
+  }
+
+  return false;
+};
+
+const defaultParseResponse = (response) => {
+  if (!response?.success) {
+    throw new Error(response?.error?.message || 'Failed to perform search');
+  }
+
+  return {
+    results: response?.data?.data || [],
+    pagination: response?.data?.pagination || DEFAULT_PAGINATION
+  };
+};
+
+const defaultErrorResolver = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Failed to perform search';
+};
+
+const usePaginatedSearch = ({
+  initialInput = '',
+  initialPagination = DEFAULT_PAGINATION,
+  searchFn,
+  parseResponse = defaultParseResponse,
+  requireInput = false,
+  debounceMs = 500,
+  onAuthError,
+  resolveErrorMessage = defaultErrorResolver,
+  toastOnError = true
+} = {}) => {
+  const navigate = useNavigate();
+  const [searchResults, setSearchResults] = useState([]);
+  const [pagination, setPagination] = useState(initialPagination);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [input, setInputState] = useState(initialInput);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const debounceTimeoutRef = useRef(null);
+  const currentInputRef = useRef(initialInput);
+
+  const defaultAuthHandler = useCallback(() => {
+    localStorage.clear();
+    navigate('/login');
+    toastService.error('Session expired. Please login again.');
+  }, [navigate]);
+
+  const authHandler = onAuthError || defaultAuthHandler;
+
+  const clearDebounce = useCallback(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+      debounceTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resetState = useCallback(() => {
+    setSearchResults([]);
+    setPagination(initialPagination);
+    setError(null);
+    setIsSearching(false);
+  }, [initialPagination]);
+
+  const shouldSkipSearch = useCallback((value) => {
+    if (!requireInput) {
+      return false;
+    }
+
+    if (typeof value === 'string') {
+      return value.trim() === '';
+    }
+
+    if (typeof value === 'object' && value !== null) {
+      return Object.values(value).every(isValueEmpty);
+    }
+
+    return value == null;
+  }, [requireInput]);
+
+  const resolveLimit = useCallback((pageState = pagination) => {
+    if (!pageState) {
+      return initialPagination.itemsPerPage || initialPagination.limit || 10;
+    }
+
+    return pageState.itemsPerPage || pageState.limit || initialPagination.itemsPerPage || 10;
+  }, [pagination, initialPagination]);
+
+  const performSearch = useCallback(async (value = currentInputRef.current, page = 1, limit = resolveLimit()) => {
+    clearDebounce();
+
+    currentInputRef.current = value;
+    setInputState(value);
+
+    if (shouldSkipSearch(value)) {
+      resetState();
+      return null;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      setIsSearching(true);
+
+      const response = await searchFn(value, page, limit);
+      const { results, pagination: nextPagination } = parseResponse(response) || {};
+
+      setSearchResults(results || []);
+      setPagination(nextPagination || initialPagination);
+
+      return response;
+    } catch (err) {
+      if (err?.response?.status === 401 || err?.response?.status === 403) {
+        authHandler();
+        return null;
+      }
+
+      const message = resolveErrorMessage(err);
+      setError(message);
+      if (toastOnError && message) {
+        toastService.error(message);
+      }
+      setIsSearching(false);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [authHandler, clearDebounce, initialPagination, parseResponse, resolveErrorMessage, resetState, resolveLimit, searchFn, shouldSkipSearch, toastOnError]);
+
+  const debouncedSearch = useCallback((value = currentInputRef.current, page = 1, limit) => {
+    clearDebounce();
+
+    const effectiveLimit = typeof limit === 'number' ? limit : resolveLimit();
+
+    debounceTimeoutRef.current = setTimeout(() => {
+      performSearch(value, page, effectiveLimit);
+    }, debounceMs);
+  }, [clearDebounce, debounceMs, performSearch, resolveLimit]);
+
+  const handlePageChange = useCallback((newPage) => {
+    performSearch(currentInputRef.current, newPage, resolveLimit());
+  }, [performSearch, resolveLimit]);
+
+  const handleLimitChange = useCallback((newLimit) => {
+    setPagination(prev => ({
+      ...prev,
+      itemsPerPage: newLimit,
+      limit: newLimit
+    }));
+
+    performSearch(currentInputRef.current, 1, newLimit);
+  }, [performSearch]);
+
+  const clearSearch = useCallback(() => {
+    clearDebounce();
+    currentInputRef.current = initialInput;
+    setInputState(initialInput);
+    resetState();
+  }, [clearDebounce, initialInput, resetState]);
+
+  const setInput = useCallback((valueOrUpdater) => {
+    setInputState(prev => {
+      const nextValue = typeof valueOrUpdater === 'function' ? valueOrUpdater(prev) : valueOrUpdater;
+      currentInputRef.current = nextValue;
+      return nextValue;
+    });
+  }, []);
+
+  useEffect(() => clearDebounce, [clearDebounce]);
+
+  return {
+    input,
+    setInput,
+    searchResults,
+    setSearchResults,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    isSearching,
+    performSearch,
+    debouncedSearch,
+    handlePageChange,
+    handleLimitChange,
+    clearSearch,
+    clearDebounce,
+    resolveLimit,
+    handleAuthError: authHandler
+  };
+};
+
+export default usePaginatedSearch;

--- a/src/hooks/usePurchaseOrders.js
+++ b/src/hooks/usePurchaseOrders.js
@@ -1,227 +1,225 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import purchaseOrderService from '../services/purchaseOrderService';
 import toastService from '../services/toastService';
+import usePaginatedSearch from './usePaginatedSearch';
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10,
+  page: 1,
+  limit: 10,
+  total: 0
+};
+
+const parsePurchaseOrdersResponse = (response) => {
+  if (response?.success === false) {
+    throw new Error(response?.error?.message || 'Failed to load purchase orders');
+  }
+
+  const rawData = response?.data?.data || response?.data || [];
+  const paginationData = response?.data?.pagination || {};
+  const currentPage = paginationData.currentPage || paginationData.page || INITIAL_PAGINATION.currentPage;
+  const itemsPerPage = paginationData.itemsPerPage || paginationData.limit || INITIAL_PAGINATION.itemsPerPage;
+  const totalItems = paginationData.totalItems || paginationData.total || INITIAL_PAGINATION.totalItems;
+
+  return {
+    results: Array.isArray(rawData) ? rawData : Array.isArray(rawData?.data) ? rawData.data : [],
+    pagination: {
+      currentPage,
+      page: currentPage,
+      totalPages: paginationData.totalPages || INITIAL_PAGINATION.totalPages,
+      totalItems,
+      total: totalItems,
+      itemsPerPage,
+      limit: itemsPerPage
+    }
+  };
+};
+
+const resolvePurchaseOrdersError = (error) => {
+  return error?.response?.data?.error?.message || error?.message || 'Gagal mengambil data purchase orders';
+};
 
 const usePurchaseOrders = () => {
-  const [purchaseOrders, setPurchaseOrders] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
-  });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
   const [searchField, setSearchField] = useState('customer_name');
-  const [debounceTimeout, setDebounceTimeout] = useState(null);
+  const searchFieldRef = useRef('customer_name');
 
-  const handleAuthError = useCallback(() => {
+  const handleAuthRedirect = useCallback(() => {
     localStorage.clear();
     window.location.href = '/login';
     toastService.error('Session expired. Please login again.');
   }, []);
 
-  const fetchPurchaseOrders = useCallback(async (page = 1, limit = 10) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const response = await purchaseOrderService.getAllPurchaseOrders(page, limit);
-      console.log('Purchase Orders API Response:', response); // Debug log
-      
-      if (response && response.success && response.data) {
-        // Handle API response structure: { success: true, data: { data: [...], pagination: {...} } }
-        const purchaseOrdersData = Array.isArray(response.data.data) ? response.data.data : [];
-        setPurchaseOrders(purchaseOrdersData);
-        setPagination(response.data.pagination || pagination);
-      } else if (response && Array.isArray(response.data)) {
-        // Handle direct array response
-        setPurchaseOrders(response.data);
-      } else {
-        setPurchaseOrders([]);
+  const {
+    input: searchQuery,
+    setInput: setSearchQuery,
+    searchResults: purchaseOrders,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    performSearch,
+    debouncedSearch,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
+    handleAuthError: authHandler,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialInput: '',
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (query, page, limit) => {
+      const trimmedQuery = typeof query === 'string' ? query.trim() : '';
+      const field = searchFieldRef.current || 'customer_name';
+      if (!trimmedQuery) {
+        return purchaseOrderService.getAllPurchaseOrders(page, limit);
       }
-    } catch (err) {
-      const errorMessage = err.message || 'Gagal mengambil data purchase orders';
-      setError(errorMessage);
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
-      } else {
-        toastService.error(errorMessage);
-      }
-      setPurchaseOrders([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [handleAuthError]);
+      const searchParams = { [field]: trimmedQuery };
+      return purchaseOrderService.searchPurchaseOrders(searchParams, page, limit);
+    },
+    parseResponse: parsePurchaseOrdersResponse,
+    resolveErrorMessage: resolvePurchaseOrdersError,
+    onAuthError: handleAuthRedirect
+  });
 
-  const searchPurchaseOrders = useCallback(async (query, field, page = 1, limit = 10) => {
-    if (!query.trim()) {
-      fetchPurchaseOrders(page, limit);
-      return;
+  const searchLoading = useMemo(() => {
+    if (typeof searchQuery !== 'string') {
+      return false;
     }
-    try {
-      setSearchLoading(true);
-      const searchParams = {};
-      searchParams[field || 'customer_name'] = query;
-      
-      const result = await purchaseOrderService.searchPurchaseOrders(searchParams, page, limit);
-      
-      if (result.success) {
-        setPurchaseOrders(result.data.data || []);
-        setPagination(result.data.pagination || pagination);
-      } else {
-        throw new Error(result.error?.message || 'Failed to search purchase orders');
-      }
-    } catch (err) {
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
-      } else {
-        toastService.error('Failed to search purchase orders');
-      }
-    } finally {
-      setSearchLoading(false);
+    return loading && Boolean(searchQuery.trim());
+  }, [loading, searchQuery]);
+
+  const fetchPurchaseOrders = useCallback((page = 1, limit = resolveLimit()) => {
+    return performSearch('', page, limit);
+  }, [performSearch, resolveLimit]);
+
+  const searchPurchaseOrders = useCallback((query, field = searchFieldRef.current, page = 1, limit = resolveLimit()) => {
+    if (field && field !== searchFieldRef.current) {
+      searchFieldRef.current = field;
+      setSearchField(field);
     }
-  }, [handleAuthError, fetchPurchaseOrders]);
+    setSearchQuery(query);
+    return performSearch(query, page, limit);
+  }, [performSearch, resolveLimit, setSearchQuery]);
+
+  const handleSearchChange = useCallback((event) => {
+    const query = event?.target ? event.target.value : event;
+    setSearchQuery(query);
+    debouncedSearch(query, 1, resolveLimit());
+  }, [debouncedSearch, resolveLimit, setSearchQuery]);
+
+  const handleSearchFieldChange = useCallback((field) => {
+    searchFieldRef.current = field;
+    setSearchField(field);
+    if (typeof searchQuery === 'string' && searchQuery.trim()) {
+      performSearch(searchQuery, 1, resolveLimit());
+    }
+  }, [performSearch, resolveLimit, searchQuery]);
+
+  const computeNextPageAfterDelete = useCallback(() => {
+    const itemsPerPage = resolveLimit();
+    const currentPage = pagination.currentPage || pagination.page || 1;
+    const totalItems = pagination.totalItems || pagination.total || purchaseOrders.length;
+    const newTotalItems = Math.max(totalItems - 1, 0);
+    const newTotalPages = Math.max(Math.ceil(newTotalItems / itemsPerPage), 1);
+    return {
+      nextPage: Math.min(currentPage, newTotalPages),
+      itemsPerPage
+    };
+  }, [pagination, purchaseOrders.length, resolveLimit]);
 
   const getPurchaseOrder = useCallback(async (id) => {
     try {
       const result = await purchaseOrderService.getPurchaseOrderById(id);
-      
-      if (result.success) {
-        return result.data;
-      } else {
-        throw new Error(result.error?.message || 'Failed to fetch purchase order details');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to fetch purchase order details');
       }
+      return result?.data;
     } catch (err) {
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
+      if (err?.message?.includes('token') || err?.message?.includes('unauthorized')) {
+        authHandler();
       } else {
-        toastService.error('Failed to load purchase order details');
+        const message = err?.response?.data?.error?.message || err?.message || 'Failed to load purchase order details';
+        toastService.error(message);
       }
       return null;
     }
-  }, [handleAuthError]);
+  }, [authHandler]);
+
+  const refreshAfterMutation = useCallback(async () => {
+    const itemsPerPage = resolveLimit();
+    const currentPage = pagination.currentPage || pagination.page || 1;
+    const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+    await performSearch(trimmedQuery, currentPage, itemsPerPage);
+  }, [pagination, performSearch, resolveLimit, searchQuery]);
 
   const createPurchaseOrder = useCallback(async (formData, files = []) => {
     try {
       const result = await purchaseOrderService.createPurchaseOrder(formData, files);
-      
-      if (result.success) {
-        toastService.success('Purchase order created successfully');
-        fetchPurchaseOrders(pagination.currentPage, pagination.itemsPerPage);
-        return result.data;
-      } else {
-        throw new Error(result.error?.message || 'Failed to create purchase order');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to create purchase order');
       }
+      toastService.success('Purchase order created successfully');
+      await refreshAfterMutation();
+      return result?.data;
     } catch (err) {
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
-      } else {
-        toastService.error(err.message || 'Failed to create purchase order');
+      if (err?.message?.includes('token') || err?.message?.includes('unauthorized')) {
+        authHandler();
+        return null;
       }
+      const message = err?.response?.data?.error?.message || err?.message || 'Failed to create purchase order';
+      toastService.error(message);
       return null;
     }
-  }, [handleAuthError, fetchPurchaseOrders, pagination]);
+  }, [authHandler, refreshAfterMutation]);
 
   const updatePurchaseOrder = useCallback(async (id, updateData) => {
     try {
       const result = await purchaseOrderService.updatePurchaseOrder(id, updateData);
-      
-      if (result.success) {
-        toastService.success('Purchase order updated successfully');
-        fetchPurchaseOrders(pagination.currentPage, pagination.itemsPerPage);
-        return result.data;
-      } else {
-        throw new Error(result.error?.message || 'Failed to update purchase order');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to update purchase order');
       }
+      toastService.success('Purchase order updated successfully');
+      await refreshAfterMutation();
+      return result?.data;
     } catch (err) {
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
-      } else {
-        toastService.error(err.message || 'Failed to update purchase order');
+      if (err?.message?.includes('token') || err?.message?.includes('unauthorized')) {
+        authHandler();
+        return null;
       }
+      const message = err?.response?.data?.error?.message || err?.message || 'Failed to update purchase order';
+      toastService.error(message);
       return null;
     }
-  }, [handleAuthError, fetchPurchaseOrders, pagination]);
+  }, [authHandler, refreshAfterMutation]);
 
   const deletePurchaseOrder = useCallback(async (id) => {
     try {
       const result = await purchaseOrderService.deletePurchaseOrder(id);
-      
-      if (result.success) {
-        toastService.success('Purchase order deleted successfully');
-        fetchPurchaseOrders(pagination.currentPage, pagination.itemsPerPage);
-        return true;
-      } else {
-        throw new Error(result.error?.message || 'Failed to delete purchase order');
+      if (result?.success === false) {
+        throw new Error(result?.error?.message || 'Failed to delete purchase order');
       }
+      toastService.success('Purchase order deleted successfully');
+      const { nextPage, itemsPerPage } = computeNextPageAfterDelete();
+      const trimmedQuery = typeof searchQuery === 'string' ? searchQuery.trim() : '';
+      await performSearch(trimmedQuery, nextPage, itemsPerPage);
+      return true;
     } catch (err) {
-      if (err.message.includes('token') || err.message.includes('unauthorized')) {
-        handleAuthError();
+      if (err?.message?.includes('token') || err?.message?.includes('unauthorized')) {
+        authHandler();
       } else {
-        toastService.error(err.message || 'Failed to delete purchase order');
+        const message = err?.response?.data?.error?.message || err?.message || 'Failed to delete purchase order';
+        setError(message);
+        toastService.error(message);
       }
       return false;
     }
-  }, [handleAuthError, fetchPurchaseOrders, pagination]);
-
-  const handlePageChange = (newPage) => {
-    if (searchQuery.trim()) {
-      searchPurchaseOrders(searchQuery, searchField, newPage, pagination.itemsPerPage);
-    } else {
-      fetchPurchaseOrders(newPage, pagination.itemsPerPage);
-    }
-  };
-
-  const handleLimitChange = (newLimit) => {
-    const newPagination = {
-      ...pagination,
-      itemsPerPage: newLimit
-    };
-    setPagination(newPagination);
-    
-    if (searchQuery.trim()) {
-      searchPurchaseOrders(searchQuery, searchField, 1, newLimit);
-    } else {
-      fetchPurchaseOrders(1, newLimit);
-    }
-  };
-
-  const handleSearchChange = (e) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (debounceTimeout) {
-      clearTimeout(debounceTimeout);
-    }
-
-    const timeout = setTimeout(() => {
-      if (!query.trim()) {
-        fetchPurchaseOrders(1, pagination.itemsPerPage);
-      } else {
-        searchPurchaseOrders(query, searchField, 1, pagination.itemsPerPage);
-      }
-    }, 500);
-
-    setDebounceTimeout(timeout);
-  };
-
-  const handleSearchFieldChange = (field) => {
-    setSearchField(field);
-    if (searchQuery.trim()) {
-      searchPurchaseOrders(searchQuery, field, 1, pagination.itemsPerPage);
-    }
-  };
+  }, [authHandler, computeNextPageAfterDelete, performSearch, searchQuery, setError]);
 
   useEffect(() => {
-    fetchPurchaseOrders(1, pagination.itemsPerPage);
-
-    return () => {
-      if (debounceTimeout) {
-        clearTimeout(debounceTimeout);
-      }
-    };
+    fetchPurchaseOrders(1, INITIAL_PAGINATION.itemsPerPage);
   }, [fetchPurchaseOrders]);
 
   return {
@@ -238,8 +236,8 @@ const usePurchaseOrders = () => {
     createPurchaseOrder,
     updatePurchaseOrder,
     getPurchaseOrder,
-    handlePageChange,
-    handleLimitChange,
+    handlePageChange: handlePageChangeInternal,
+    handleLimitChange: handleLimitChangeInternal,
     handleSearchChange,
     handleSearchFieldChange,
     refetch: fetchPurchaseOrders

--- a/src/hooks/useSupplierSearch.js
+++ b/src/hooks/useSupplierSearch.js
@@ -1,126 +1,68 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import usePaginatedSearch from './usePaginatedSearch';
 import supplierService from '@/services/supplierService';
-import toastService from '@/services/toastService';
+
+const INITIAL_PAGINATION = {
+  currentPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+  itemsPerPage: 10
+};
+
+const parseSupplierResponse = (response) => {
+  if (!response?.success) {
+    throw new Error(response?.message || 'Gagal mencari supplier');
+  }
+
+  const data = response.data || {};
+
+  return {
+    results: data.data || [],
+    pagination: data.pagination || INITIAL_PAGINATION
+  };
+};
+
+const resolveSupplierError = (error) => {
+  return error?.response?.data?.message || error?.message || 'Gagal mencari supplier';
+};
 
 const useSupplierSearch = () => {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState([]);
-  const [pagination, setPagination] = useState({
-    currentPage: 1,
-    totalPages: 1,
-    totalItems: 0,
-    itemsPerPage: 10
+  const {
+    input: searchQuery,
+    setInput: setSearchQuery,
+    searchResults,
+    setSearchResults,
+    pagination,
+    setPagination,
+    loading,
+    error,
+    setError,
+    isSearching,
+    performSearch,
+    debouncedSearch,
+    handlePageChange,
+    handleLimitChange,
+    clearSearch,
+    handleAuthError,
+    resolveLimit
+  } = usePaginatedSearch({
+    initialInput: '',
+    initialPagination: INITIAL_PAGINATION,
+    searchFn: (query, page, limit) => supplierService.searchSuppliers(query, page, limit),
+    parseResponse: parseSupplierResponse,
+    resolveErrorMessage: resolveSupplierError,
+    requireInput: true
   });
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [isSearching, setIsSearching] = useState(false);
-  const navigate = useNavigate();
-  const debounceTimeoutRef = useRef(null);
 
-  const handleAuthError = useCallback(() => {
-    localStorage.clear();
-    navigate('/login');
-    toastService.error('Session expired. Please login again.');
-  }, [navigate]);
-
-  const searchSuppliers = useCallback(async (query, page = 1, limit = 10) => {
-    if (!query.trim()) {
-      setSearchResults([]);
-      setPagination({
-        currentPage: 1,
-        totalPages: 1,
-        totalItems: 0,
-        itemsPerPage: limit
-      });
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-    setIsSearching(true);
-
-    try {
-      const result = await supplierService.searchSuppliers(query, page, limit);
-      if (result.success) {
-        setSearchResults(result.data?.data || []);
-        setPagination({
-          currentPage: result.data?.pagination?.currentPage || 1,
-          totalPages: result.data?.pagination?.totalPages || 1,
-          totalItems: result.data?.pagination?.totalItems || 0,
-          itemsPerPage: result.data?.pagination?.itemsPerPage || 10
-        });
-      } else {
-        throw new Error(result.message || 'Gagal mencari supplier');
-      }
-    } catch (err) {
-      const errorMessage = err.response?.data?.message || err.message || 'Gagal mencari supplier';
-      
-      if (err.response?.status === 401 || err.response?.status === 403) {
-        handleAuthError();
-        return;
-      }
-      
-      toastService.error(errorMessage);
-      setError(errorMessage);
-      setSearchResults([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [handleAuthError]);
-
-  const debouncedSearch = useCallback((query, page = 1, limit = 10) => {
-    // Clear existing timeout
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
-    }
-
-    // Set new timeout
-    debounceTimeoutRef.current = setTimeout(() => {
-      searchSuppliers(query, page, limit);
-    }, 500); // 500ms delay
-  }, [searchSuppliers]);
-
-  const handleSearchChange = useCallback((e) => {
-    const query = e.target.value;
+  const handleSearchChange = useCallback((event) => {
+    const query = event.target.value;
     setSearchQuery(query);
-    debouncedSearch(query, 1, pagination.itemsPerPage);
-  }, [debouncedSearch, pagination.itemsPerPage]);
+    debouncedSearch(query, 1, resolveLimit(pagination));
+  }, [debouncedSearch, pagination, resolveLimit, setSearchQuery]);
 
-  const handlePageChange = useCallback((newPage) => {
-    if (searchQuery.trim()) {
-      searchSuppliers(searchQuery, newPage, pagination.itemsPerPage);
-    }
-  }, [searchQuery, searchSuppliers, pagination.itemsPerPage]);
-
-  const handleLimitChange = useCallback((newLimit) => {
-    setPagination(prev => ({
-      ...prev,
-      itemsPerPage: newLimit
-    }));
-    
-    if (searchQuery.trim()) {
-      searchSuppliers(searchQuery, 1, newLimit);
-    }
-  }, [searchQuery, searchSuppliers]);
-
-  const clearSearch = useCallback(() => {
-    setSearchQuery('');
-    setSearchResults([]);
-    setPagination({
-      currentPage: 1,
-      totalPages: 1,
-      totalItems: 0,
-      itemsPerPage: 10
-    });
-    setError(null);
-    setIsSearching(false);
-    
-    // Clear any pending debounced search
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
-    }
-  }, []);
+  const clearSearchState = useCallback(() => {
+    clearSearch();
+  }, [clearSearch]);
 
   const getSearchSuggestions = useCallback(async (query, limit = 5) => {
     if (!query.trim() || query.length < 2) {
@@ -128,9 +70,9 @@ const useSupplierSearch = () => {
     }
 
     try {
-      const result = await supplierService.searchSuppliers(query, 1, limit);
-      if (result.success) {
-        return (result.data?.data || []).map(supplier => ({
+      const response = await supplierService.searchSuppliers(query, 1, limit);
+      if (response.success) {
+        return (response.data?.data || []).map((supplier) => ({
           id: supplier.id,
           name: supplier.name,
           code: supplier.code,
@@ -140,17 +82,8 @@ const useSupplierSearch = () => {
     } catch (err) {
       console.error('Error getting search suggestions:', err);
     }
-    
-    return [];
-  }, []);
 
-  // Cleanup timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceTimeoutRef.current) {
-        clearTimeout(debounceTimeoutRef.current);
-      }
-    };
+    return [];
   }, []);
 
   return {
@@ -160,13 +93,17 @@ const useSupplierSearch = () => {
     pagination,
     loading,
     error,
+    setError,
     isSearching,
     handleSearchChange,
     handlePageChange,
     handleLimitChange,
-    clearSearch,
-    searchSuppliers,
-    getSearchSuggestions
+    clearSearch: clearSearchState,
+    searchSuppliers: performSearch,
+    getSearchSuggestions,
+    setSearchResults,
+    setPagination,
+    handleAuthError
   };
 };
 


### PR DESCRIPTION
## Summary
- refactor admin listing hooks to delegate pagination, search, and deletion flows to usePaginatedSearch
- normalize API response parsing, error handling, and auth redirects across companies, inventories, suppliers, invoices, packings, purchase orders, term of payments, and surat jalan hooks
- add shared pagination utilities for advanced packings filters and mutation refreshes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d0a590116483319790a26ca31914be