### PR TITLE
fix: auto-format NPWP 15-digit to 16-digit with 0 prefix on input

### DIFF
--- a/src/components/customers/CustomerDetailCardEditable.jsx
+++ b/src/components/customers/CustomerDetailCardEditable.jsx
@@ -145,6 +145,26 @@ const CustomerDetailCardEditable = ({ customer, onClose, onUpdate }) => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
+  /**
+   * Auto-format NPWP on blur:
+   * - Strip non-digit characters
+   * - If 15 digits (old format), prepend '0' to convert to 16-digit format
+   */
+  const handleNPWPBlur = (e) => {
+    const { value } = e.target;
+    if (!value) return;
+
+    const cleanValue = value.replace(/[^0-9]/g, '');
+
+    // If 15 digits (old NPWP format), auto-prepend '0' to make 16 digits
+    if (cleanValue.length === 15) {
+      setFormData(prev => ({ ...prev, NPWP: `0${cleanValue}` }));
+    } else if (cleanValue !== value) {
+      // If value had non-digit chars, clean it
+      setFormData(prev => ({ ...prev, NPWP: cleanValue }));
+    }
+  };
+
   const handleAutocompleteChange = (name, value) => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
@@ -317,8 +337,14 @@ const CustomerDetailCardEditable = ({ customer, onClose, onUpdate }) => {
                     name="NPWP"
                     value={formData?.NPWP || ''}
                     onChange={handleInputChange}
+                    onBlur={handleNPWPBlur}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    placeholder="16 digit (NPWP 15 digit otomatis ditambah 0 di depan)"
+                    maxLength={20}
                   />
+                  <p className="mt-1 text-xs text-gray-500">
+                    Format 16 digit. NPWP 15 digit akan otomatis ditambah 0 di depan.
+                  </p>
                 </div>
 
                 <div>

--- a/src/components/customers/CustomerForm.jsx
+++ b/src/components/customers/CustomerForm.jsx
@@ -84,6 +84,26 @@ const CustomerForm = ({ onSubmit, onClose, initialData = {}, loading = false, er
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
+  /**
+   * Auto-format NPWP on blur:
+   * - Strip non-digit characters
+   * - If 15 digits (old format), prepend '0' to convert to 16-digit format
+   */
+  const handleNPWPBlur = (e) => {
+    const { value } = e.target;
+    if (!value) return;
+
+    const cleanValue = value.replace(/[^0-9]/g, '');
+
+    // If 15 digits (old NPWP format), auto-prepend '0' to make 16 digits
+    if (cleanValue.length === 15) {
+      setFormData(prev => ({ ...prev, NPWP: `0${cleanValue}` }));
+    } else if (cleanValue !== value) {
+      // If value had non-digit chars, clean it
+      setFormData(prev => ({ ...prev, NPWP: cleanValue }));
+    }
+  };
+
   const handleAutocompleteChange = (name, value) => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
@@ -242,10 +262,15 @@ const CustomerForm = ({ onSubmit, onClose, initialData = {}, loading = false, er
             name='NPWP'
             value={formData.NPWP}
             onChange={handleChange}
+            onBlur={handleNPWPBlur}
             disabled={isLoading}
             className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100'
-            placeholder='cth. 01.234.567.8-901.000'
+            placeholder='cth. 0123456789012345 (16 digit)'
+            maxLength={20}
           />
+          <p className="mt-1 text-xs text-gray-500">
+            Format 16 digit. NPWP 15 digit akan otomatis ditambah 0 di depan.
+          </p>
         </div>
 
         {/* NPWP Address */}

--- a/src/components/groupCustomers/GroupCustomerDetailCard.jsx
+++ b/src/components/groupCustomers/GroupCustomerDetailCard.jsx
@@ -95,6 +95,24 @@ const GroupCustomerDetailCard = ({ groupCustomer, onClose, onUpdate, loading = f
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
+  /**
+   * Auto-format NPWP on blur:
+   * - Strip non-digit characters
+   * - If 15 digits (old format), prepend '0' to convert to 16-digit format
+   */
+  const handleNPWPBlur = (e) => {
+    const { value } = e.target;
+    if (!value) return;
+
+    const cleanValue = value.replace(/[^0-9]/g, '');
+
+    if (cleanValue.length === 15) {
+      setFormData(prev => ({ ...prev, npwp: `0${cleanValue}` }));
+    } else if (cleanValue !== value) {
+      setFormData(prev => ({ ...prev, npwp: cleanValue }));
+    }
+  };
+
   if (!groupCustomer) return null;
 
   const isDeleted = Boolean(groupCustomer?.is_deleted);
@@ -245,9 +263,14 @@ const GroupCustomerDetailCard = ({ groupCustomer, onClose, onUpdate, loading = f
                           name="npwp"
                           value={formData?.npwp || ''}
                           onChange={handleInputChange}
+                          onBlur={handleNPWPBlur}
                           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                          placeholder="Masukkan NPWP (15 digit)"
+                          placeholder="Masukkan NPWP (16 digit)"
+                          maxLength={20}
                         />
+                        <p className="mt-1 text-xs text-gray-500">
+                          Format 16 digit. NPWP 15 digit akan otomatis ditambah 0 di depan.
+                        </p>
                       </div>
 
                       <div>

--- a/src/components/groupCustomers/GroupCustomerForm.jsx
+++ b/src/components/groupCustomers/GroupCustomerForm.jsx
@@ -7,6 +7,7 @@ const GroupCustomerForm = ({ initialData = null, onSubmit, onCancel, isEdit = fa
     loading,
     errors,
     handleInputChange,
+    handleNPWPBlur,
     handleSubmit,
     resetForm,
     parentGroupOptions,
@@ -130,12 +131,17 @@ const GroupCustomerForm = ({ initialData = null, onSubmit, onCancel, isEdit = fa
           name="npwp"
           value={formData.npwp}
           onChange={handleInputChange}
+          onBlur={handleNPWPBlur}
           disabled={loading}
           className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 ${
             errors.npwp ? 'border-red-500' : 'border-gray-300'
           }`}
-          placeholder="cth. 01.234.567.8-901.000"
+          placeholder="cth. 0123456789012345 (16 digit)"
+          maxLength={20}
         />
+        <p className="mt-1 text-xs text-gray-500">
+          Format 16 digit. NPWP 15 digit akan otomatis ditambah 0 di depan.
+        </p>
         {errors.npwp && (
           <p className="mt-1 text-sm text-red-600">{errors.npwp}</p>
         )}

--- a/src/hooks/useGroupCustomerForm.js
+++ b/src/hooks/useGroupCustomerForm.js
@@ -54,9 +54,12 @@ const useGroupCustomerForm = (initialData = null) => {
       newErrors.nama_group = 'Nama group customer wajib diisi';
     }
 
-    // Optional validation for NPWP format if provided
-    if (formData.npwp && formData.npwp.trim() && !/^\d{15}$/.test(formData.npwp.replace(/\D/g, ''))) {
-      newErrors.npwp = 'Format NPWP tidak valid (harus 15 digit)';
+    // Optional validation for NPWP format if provided (accept 15 or 16 digits)
+    if (formData.npwp && formData.npwp.trim()) {
+      const cleanNpwp = formData.npwp.replace(/\D/g, '');
+      if (cleanNpwp.length < 15 || cleanNpwp.length > 16) {
+        newErrors.npwp = 'Format NPWP tidak valid (harus 15 atau 16 digit)';
+      }
     }
 
     setErrors(newErrors);
@@ -95,7 +98,14 @@ const useGroupCustomerForm = (initialData = null) => {
         kode_group: formData.kode_group.trim(),
         nama_group: formData.nama_group.trim(),
         alamat: formData.alamat.trim() || null,
-        npwp: formData.npwp.trim() || null,
+        npwp: (() => {
+          const raw = formData.npwp.trim();
+          if (!raw) return null;
+          const clean = raw.replace(/\D/g, '');
+          // Auto-convert 15 digit to 16 digit by prepending '0'
+          if (clean.length === 15) return `0${clean}`;
+          return clean;
+        })(),
         parentGroupCustomerId: formData.parentGroupCustomerId || null
       };
 
@@ -177,12 +187,31 @@ const useGroupCustomerForm = (initialData = null) => {
     setErrors({});
   }, []);
 
+  /**
+   * Auto-format NPWP on blur:
+   * - Strip non-digit characters
+   * - If 15 digits (old format), prepend '0' to convert to 16-digit format
+   */
+  const handleNPWPBlur = useCallback((e) => {
+    const { value } = e.target;
+    if (!value) return;
+
+    const cleanValue = value.replace(/[^0-9]/g, '');
+
+    if (cleanValue.length === 15) {
+      setFormData(prev => ({ ...prev, npwp: `0${cleanValue}` }));
+    } else if (cleanValue !== value) {
+      setFormData(prev => ({ ...prev, npwp: cleanValue }));
+    }
+  }, []);
+
   return {
     formData,
     setFormData,
     loading,
     errors,
     handleInputChange,
+    handleNPWPBlur,
     handleSubmit,
     resetForm,
     setFieldError,


### PR DESCRIPTION
- Add onBlur handler to auto-prepend '0' when user inputs 15-digit NPWP
- Strip non-digit characters on blur for clean storage
- Update validation to accept both 15 and 16 digit NPWP
- Auto-convert 15->16 digit on form submit
- Add hint text explaining the auto-format behavior
- Applied to CustomerForm, CustomerDetailCardEditable, GroupCustomerForm, and GroupCustomerDetailCard