### PR TITLE
🎨 Palette: Add ARIA labels to close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Missing ARIA labels on DetailCard and Modal close buttons
+**Learning:** This application extensively uses `<XMarkIcon />` for close buttons in DetailCards and Modals without providing text alternatives. Screen readers would just announce "button" or the SVG contents without context.
+**Action:** When creating or modifying new DetailCards or Modals, always ensure the close button includes an explicit `aria-label="Close"` or `aria-label="Tutup"` to maintain accessibility.

--- a/src/components/fakturPajak/FakturPajakDetailCard.jsx
+++ b/src/components/fakturPajak/FakturPajakDetailCard.jsx
@@ -430,7 +430,7 @@ const FakturPajakDetailCard = ({ fakturPajak, onClose, loading = false, updateFa
                 </button>
               )}
               {onClose && (
-                <button onClick={onClose} className="p-1 rounded hover:bg-gray-100" title="Close">
+                <button onClick={onClose} className="p-1 rounded hover:bg-gray-100" title="Close" aria-label="Close detail">
                   <XMarkIcon className="w-4 h-4 text-gray-500" />
                 </button>
               )}

--- a/src/components/invoicePengiriman/InvoicePengirimanDetailCard.jsx
+++ b/src/components/invoicePengiriman/InvoicePengirimanDetailCard.jsx
@@ -87,7 +87,7 @@ const InvoicePengirimanDetailCard = ({ invoice, onClose, loading = false, onUpda
                 <PencilIcon className='w-3 h-3 mr-1' />Edit
               </button>
               {onClose && (
-                <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close'>
+                <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close' aria-label='Close detail'>
                   <XMarkIcon className='w-4 h-4 text-gray-500' />
                 </button>
               )}

--- a/src/components/kwitansi/KwitansiDetailCard.jsx
+++ b/src/components/kwitansi/KwitansiDetailCard.jsx
@@ -292,7 +292,7 @@ const KwitansiDetailCard = ({
                 </button>
               )} */}
               {onClose && (
-                <button onClick={onClose} className="p-1 rounded hover:bg-gray-100" title="Close">
+                <button onClick={onClose} className="p-1 rounded hover:bg-gray-100" title="Close" aria-label="Close detail">
                   <XMarkIcon className="w-4 h-4 text-gray-500" />
                 </button>
               )}

--- a/src/components/laporanPenerimaanBarang/LaporanPenerimaanBarangDetailCard.jsx
+++ b/src/components/laporanPenerimaanBarang/LaporanPenerimaanBarangDetailCard.jsx
@@ -308,7 +308,7 @@ const LaporanPenerimaanBarangDetailCard = ({
         <div className='flex items-center gap-1'>
           <StatusBadge status={statusLabel || '-'} variant={statusVariant} size='xs' />
           {onClose && (
-            <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close'>
+            <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close' aria-label='Close detail'>
               <XMarkIcon className='w-4 h-4 text-gray-500' />
             </button>
           )}

--- a/src/components/molecules/NotificationBell.jsx
+++ b/src/components/molecules/NotificationBell.jsx
@@ -311,7 +311,7 @@ const NotificationBell = () => {
       <button
         ref={bellRef}
         onClick={handleBellClick}
-        className='relative p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors'
+        className='relative p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors' aria-label='Notifications'
       >
         <svg
           className='w-6 h-6'
@@ -438,7 +438,7 @@ const NotificationBell = () => {
                           <button
                             onClick={() => handleDeleteNotification(notification.id)}
                             className='p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-colors'
-                            title='Delete notification'
+                            title='Delete notification' aria-label='Delete notification'
                           >
                             <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
                               <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />
@@ -520,7 +520,7 @@ const NotificationBell = () => {
               </div>
               <button
                 onClick={handleCloseDetail}
-                className='p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors'
+                className='p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors' aria-label='Close detail'
               >
                 <svg className='w-5 h-5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
                   <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M6 18L18 6M6 6l12 12' />

--- a/src/components/packings/PackingDetailCard.jsx
+++ b/src/components/packings/PackingDetailCard.jsx
@@ -89,7 +89,7 @@ const PackingDetailCard = ({ packing, onClose, loading = false }) => {
         </div>
         <div className="flex items-center gap-1">
           {onClose && (
-            <button onClick={onClose} className="p-1 hover:bg-gray-100 rounded" title="Close">
+            <button onClick={onClose} className="p-1 hover:bg-gray-100 rounded" title="Close" aria-label="Close detail">
               <XMarkIcon className="w-4 h-4 text-gray-500" />
             </button>
           )}

--- a/src/components/purchaseOrders/PurchaseOrderDetailCard.jsx
+++ b/src/components/purchaseOrders/PurchaseOrderDetailCard.jsx
@@ -394,7 +394,7 @@ const PurchaseOrderDetailCard = ({ order, onClose, onUpdate }) => {
             <p className='text-xs text-gray-600'>{order?.po_number || 'N/A'}</p>
           </div>
         </div>
-        <button onClick={onClose} className='p-1 rounded hover:bg-gray-100' title="Close">
+        <button onClick={onClose} className='p-1 rounded hover:bg-gray-100' title="Close" aria-label="Close detail">
           <XMarkIcon className='w-4 h-4 text-gray-500' />
         </button>
       </div>

--- a/src/components/reportPoSuppliers/EditTagihanModal.jsx
+++ b/src/components/reportPoSuppliers/EditTagihanModal.jsx
@@ -102,7 +102,7 @@ const EditTagihanModal = ({ show, onClose, onSubmit, record }) => {
               {record.supplier?.name} â€” {record.item?.nama_barang} â€” {record.movementNumber}
             </p>
           </div>
-          <button type='button' onClick={onClose} className='rounded p-1 hover:bg-white/20'>
+          <button type='button' onClick={onClose} className='rounded p-1 hover:bg-white/20' aria-label='Tutup modal'>
             <XMarkIcon className='h-5 w-5' />
           </button>
         </div>

--- a/src/components/stockMovements/CreateStockInModal.jsx
+++ b/src/components/stockMovements/CreateStockInModal.jsx
@@ -383,7 +383,7 @@ const CreateStockInModal = ({ onClose, onSuccess, editMovement = null }) => {
         {/* ── Header ── */}
         <div className='flex items-center justify-between bg-gradient-to-r from-indigo-600 to-indigo-700 px-6 py-3.5'>
           <h2 className='text-sm font-bold tracking-wide text-white'>{isEdit ? 'Edit Stock In' : 'Stock In'}</h2>
-          <button type='button' onClick={onClose} className='rounded-lg p-1 text-white/70 transition-colors hover:bg-white/15 hover:text-white'>
+          <button type='button' onClick={onClose} className='rounded-lg p-1 text-white/70 transition-colors hover:bg-white/15 hover:text-white' aria-label='Tutup modal'>
             <XMarkIcon className='h-5 w-5' />
           </button>
         </div>

--- a/src/components/supplierItemPrices/SupplierItemPriceFormModal.jsx
+++ b/src/components/supplierItemPrices/SupplierItemPriceFormModal.jsx
@@ -93,7 +93,7 @@ const SupplierItemPriceFormModal = ({ show, onClose, onSubmit, editData = null }
       <div className='w-full max-w-lg overflow-hidden rounded-lg bg-white shadow-xl ring-1 ring-gray-200'>
         <div className='flex items-center justify-between border-b border-gray-200 bg-indigo-600 px-5 py-3 text-white'>
           <h2 className='text-base font-semibold'>{isEdit ? 'Edit' : 'Tambah'} Harga Item Supplier</h2>
-          <button type='button' onClick={onClose} className='rounded p-1 hover:bg-white/20'><XMarkIcon className='h-5 w-5' /></button>
+          <button type='button' onClick={onClose} className='rounded p-1 hover:bg-white/20' aria-label='Close form'><XMarkIcon className='h-5 w-5' /></button>
         </div>
 
         <form onSubmit={handleSubmit} className='px-5 py-4 space-y-3'>

--- a/src/components/suratJalan/SuratJalanDetailCard.jsx
+++ b/src/components/suratJalan/SuratJalanDetailCard.jsx
@@ -192,7 +192,7 @@ const SuratJalanDetailCard = ({ suratJalan, onClose, loading = false, onUpdate }
                 <PencilIcon className='w-3 h-3 mr-1' />Edit
               </button>
               {onClose && (
-                <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close'>
+                <button onClick={onClose} className='p-1 hover:bg-gray-100 rounded' title='Close' aria-label='Close detail'>
                   <XMarkIcon className='w-4 h-4 text-gray-500' />
                 </button>
               )}


### PR DESCRIPTION
💡 What: Added `aria-label` to icon-only close buttons in various `DetailCard` and `Modal` components across the application. Added a journal entry to `.Jules/palette.md` to document this accessibility pattern.
🎯 Why: Screen reader users previously lacked context for these buttons, as they only announced "button" or the SVG contents. Providing descriptive labels like "Close detail" or "Tutup modal" clarifies their function.
♿ Accessibility: Improved keyboard and screen reader accessibility by ensuring all close actions have text alternatives.

---
*PR created automatically by Jules for task [6661876593542612895](https://jules.google.com/task/6661876593542612895) started by @nandocoeg*